### PR TITLE
fix hTag matching

### DIFF
--- a/src/manifest.coffee
+++ b/src/manifest.coffee
@@ -81,7 +81,7 @@ class ManifestFile
                         new_img = img.replace src[2], url
                         html = html.replace img, new_img
 
-            hTags = html.match /<h([1-6])>.+<\/h\1>/gi
+            hTags = html.match /<h([1-6])[^>]*>.+<\/h\1>/gi
             for hTag in hTags || []
                 title = hTag.substring hTag.indexOf('>') + 1, hTag.lastIndexOf('<')
                 anchor = S(title).stripTags().decodeHTMLEntities().slugify().s


### PR DESCRIPTION
Hi folks !
I noticed that the regex used for hTag recognition is too restrictive, and that results in missing anchors. I changed it from `<h([1-6])>.+<\/h\1>` to `<h([1-6])[^>]*>.+<\/h\1>`.

This way it handles cases like `<h1 id="title">some title</h1>`
This should fix https://github.com/maximebf/beautiful-docs/issues/35
