### PR TITLE
Use fixed version numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
   },
 
   "dependencies": {
-    "coffee-script": ">=1.6.3",
-    "eco": ">=1.0.0",
-    "express": ">=3.3.4",
-    "less": ">=1.4.1",
-    "marked": ">=0.2.9",
-    "underscore": ">=1.5.1",
-    "async": ">=0.2.9",
-    "string": ">=1.5.0",
-    "js-yaml": ">=2.1.0"
+    "coffee-script": "1.6.3",
+    "eco": "1.0.0",
+    "express": "3.3.4",
+    "less": "1.4.1",
+    "marked": "0.2.9",
+    "underscore": "1.5.1",
+    "async": "0.2.9",
+    "string": "1.5.0",
+    "js-yaml": "2.1.0"
   },
 
   "main": "./lib/index.js",


### PR DESCRIPTION
My development environment just blew up because npm installed Less 2.something. Currently the `>=` prefix allows the newest major version of a dependency to be installed and according to (SemVer)[http://semver.org/] major version number changes are made "when you make incompatible API changes".